### PR TITLE
url: ovirt-engine -> eayunos

### DIFF
--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -199,35 +199,35 @@
               <groupId>org.ovirt.engine.ui</groupId>
               <artifactId>userportal</artifactId>
               <bundleFileName>userportal.war</bundleFileName>
-              <contextRoot>/ovirt-engine/userportal</contextRoot>
+              <contextRoot>/eayunos/userportal</contextRoot>
             </webModule>
 
             <webModule>
               <groupId>org.ovirt.engine.ui</groupId>
               <artifactId>webadmin</artifactId>
               <bundleFileName>webadmin.war</bundleFileName>
-              <contextRoot>/ovirt-engine/webadmin</contextRoot>
+              <contextRoot>/eayunos/webadmin</contextRoot>
             </webModule>
 
             <webModule>
               <groupId>org.ovirt.engine.core</groupId>
               <artifactId>services</artifactId>
               <bundleFileName>services.war</bundleFileName>
-              <contextRoot>/ovirt-engine/services</contextRoot>
+              <contextRoot>/eayunos/services</contextRoot>
             </webModule>
 
             <webModule>
               <groupId>org.ovirt.engine.core</groupId>
               <artifactId>docs</artifactId>
               <bundleFileName>docs.war</bundleFileName>
-              <contextRoot>/ovirt-engine/docs</contextRoot>
+              <contextRoot>/eayunos/docs</contextRoot>
             </webModule>
 
             <webModule>
               <groupId>org.ovirt.engine.core</groupId>
               <artifactId>welcome</artifactId>
               <bundleFileName>welcome.war</bundleFileName>
-              <contextRoot>/ovirt-engine</contextRoot>
+              <contextRoot>/eayunos</contextRoot>
             </webModule>
 
             <!-- ** EJB-JARs -->

--- a/packaging/conf/ovirt-engine-root-redirect.conf.in
+++ b/packaging/conf/ovirt-engine-root-redirect.conf.in
@@ -1,1 +1,1 @@
-RedirectMatch ^/$ /ovirt-engine/
+RedirectMatch ^/$ /eayunos/

--- a/packaging/services/ovirt-engine/ovirt-engine.conf.in
+++ b/packaging/services/ovirt-engine/ovirt-engine.conf.in
@@ -148,7 +148,7 @@ ENGINE_JAVA_MODULEPATH="${ENGINE_USR}/modules/common"
 # /usr/share/ovirt-engine:
 #
 ENGINE_APPS="engine.ear restapi.war legacy_restapi.war"
-ENGINE_URI=/ovirt-engine
+ENGINE_URI=/eayunos
 
 #
 # Flags to enable or disable the web server (the proxy) and the

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </modules>
 
   <properties>
-    <application.baseuri>/ovirt-engine/api</application.baseuri>
+    <application.baseuri>/eayunos/api</application.baseuri>
     <!--  Version Info -->
     <engine.version>${project.version}</engine.version>
 


### PR DESCRIPTION
Bug #7003，ovirt-engine 管理平台中的，将原URL中的 ovirt-engine 修改
为了 eayunos。管理平台的访问地址变为：Protocol:IP/eayunos