### PR TITLE
Fixup of cf0cbddb9910ad86376ecb72e93814fb2bf94180

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,7 @@ install_artifacts:
 		"$(DESTDIR)$(DATA_DIR)/restapi.war" \
 		"$(DESTDIR)$(DATA_DIR)/legacy_restapi.war"
 	sed -i \
-		's|<context-root>/ovirt-engine/api</context-root>|<context-root>/api</context-root>|' \
+		's|<context-root>/eayunos/api</context-root>|<context-root>/api</context-root>|' \
 		"$(DESTDIR)$(DATA_DIR)/legacy_restapi.war/WEB-INF/jboss-web.xml"
 	sed -i \
 		's|<param-value>Basic realm="RESTAPI"</param-value>|<param-value>Basic realm="ENGINE"</param-value>|' \


### PR DESCRIPTION
according to db10f7e8138dae2306ae017dd559833c076119b5, restapi.war
is served for eayunos/api, while legacy_restapi.war is served
for /api, so sed command need update url inside legacy_restapi.war

Signed-off-by: walteryang47 <walteryang47@gmail.com>