### PR TITLE
Enable global config of cluster policy power management by default

### DIFF
--- a/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendHostsResource.java
+++ b/backend/manager/modules/restapi/jaxrs/src/main/java/org/ovirt/engine/api/restapi/resource/BackendHostsResource.java
@@ -92,6 +92,7 @@ public class BackendHostsResource extends AbstractBackendCollectionResource<Host
         validateParameters(host, "name", "address");
         VdsStatic staticHost = getMapper(Host.class, VdsStatic.class).map(host, null);
         staticHost.setVdsGroupId(getClusterId(host));
+        staticHost.setDisablePowerManagementPolicy(true);
         AddVdsActionParameters addParams = new AddVdsActionParameters(staticHost, host.getRootPassword());
         if (host.isSetOverrideIptables()) {
             addParams.setOverrideFirewall(host.isOverrideIptables());

--- a/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/hosts/HostModel.java
+++ b/frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/models/hosts/HostModel.java
@@ -609,7 +609,7 @@ public abstract class HostModel extends Model implements HasValidatedTabs {
         getUpdateHostsCommand().setIsExecutionAllowed(false);
 
         setDisableAutomaticPowerManagement(new EntityModel<Boolean>());
-        getDisableAutomaticPowerManagement().setEntity(false);
+        getDisableAutomaticPowerManagement().setEntity(true);
         setPmKdumpDetection(new EntityModel<Boolean>());
         getPmKdumpDetection().setEntity(true);
 

--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -804,6 +804,7 @@ select fn_db_add_config_value_for_versions_up_to('InitialSizeSparseDiskSupported
 
 select fn_db_add_config_value('CheckMixedRhelVersions','false','general');
 select fn_db_add_config_value_for_versions_up_to('CheckMixedRhelVersions','true','3.5');
+select fn_db_add_config_value('EnableAutomaticHostPowerManagement','true','general');
 ------------------------------------------------------------------------------------
 --                  Update with override section
 ------------------------------------------------------------------------------------


### PR DESCRIPTION
Because of this change, DisablePowerManagementPolicy of vdsStatic
is set ot true by defualt.
Fix of #7630

Signed-off-by: walteryang47 <walteryang47@gmail.com>