### PR TITLE
Run vm: Validate storge domains in which vm's disks resides

### DIFF
--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/config/ConfigValues.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/config/ConfigValues.java
@@ -1877,7 +1877,7 @@ public enum ConfigValues {
     GlusterPeerStatusRetries,
 
     @TypeConverterAttribute(Integer.class)
-    @DefaultValueAttribute("1")
+    @DefaultValueAttribute("10")
     AutoStartVmsRunnerIntervalInSeconds,
 
     @TypeConverterAttribute(Integer.class)

--- a/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
+++ b/packaging/dbscripts/upgrade/pre_upgrade/0000_config.sql
@@ -977,7 +977,7 @@ select fn_db_update_config_value('VM64BitMaxMemorySizeInMB','2097152','3.3');
 select fn_db_update_config_value('VM64BitMaxMemorySizeInMB','4096000','3.4');
 select fn_db_update_config_value('VM64BitMaxMemorySizeInMB','4096000','3.5');
 select fn_db_update_config_value('VM64BitMaxMemorySizeInMB','4194304','3.6');
-select fn_db_update_config_value('AutoStartVmsRunnerIntervalInSeconds','1','general');
+select fn_db_update_config_value('AutoStartVmsRunnerIntervalInSeconds','10','general');
 select fn_db_update_config_value('AllowEditingHostedEngine','true','general');
 
 -- enable migration, memory snapshot and suspend in the ppc64 architecture


### PR DESCRIPTION
Fix of #9036

So HA vms can be restarted as soon as vm's storage domains are
changed to "up" stat.

This fix is not efficient, So config value
"AutoStartVmsRunnerIntervalInSeconds" has increased so that there
is low overhead when HA vms are many.

Signed-off-by: PanLiyang <liyang.pan@eayun.com>